### PR TITLE
Pin iconv-lite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "buffer-equals": "^1.0.3",
-    "iconv-lite": "^0.4.7"
+    "iconv-lite": "0.4.11"
   }
 }


### PR DESCRIPTION
0.4.12 is a breaking version, `extendNodeEncodings` is not supported anymore.
https://github.com/ashtuchkin/iconv-lite/issues/107
