### PR TITLE
Node v4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 
 node_js:
-  - '0.12'
-  - '0.10'
+  - stable
+  - 6
+  - 4
+  - 0
 
 sudo: false
 

--- a/js/StringFinder.js
+++ b/js/StringFinder.js
@@ -1,3 +1,4 @@
+"use strict";
 var StringFinder = (function () {
     function StringFinder(needles) {
         if (needles instanceof RegExp) {
@@ -34,5 +35,5 @@ var StringFinder = (function () {
         return matches;
     };
     return StringFinder;
-})();
+}());
 module.exports = StringFinder;

--- a/js/StringFinder.spec.js
+++ b/js/StringFinder.spec.js
@@ -1,3 +1,4 @@
+"use strict";
 var sinonChai = require('./test-common');
 var expect = sinonChai.expect;
 var StringFinder = require('./StringFinder');
@@ -11,12 +12,8 @@ describe('StringFinder', function () {
                     new StringFinder(['foo', 'bar'])
                 ];
             }).not.to.throw;
-            expect(function () {
-                new StringFinder(void (0));
-            }).to.throw('Unexpected type in StringFinder constructor argument: undefined');
-            expect(function () {
-                new StringFinder(2);
-            }).to.throw('Unexpected type in StringFinder constructor argument: number');
+            expect(function () { new StringFinder(void (0)); }).to.throw('Unexpected type in StringFinder constructor argument: undefined');
+            expect(function () { new StringFinder(2); }).to.throw('Unexpected type in StringFinder constructor argument: number');
         });
         it('requires regular expression to have the global flag', function () {
             var fn = function () {

--- a/js/linez.spec.js
+++ b/js/linez.spec.js
@@ -1,4 +1,6 @@
+"use strict";
 var iconv = require('iconv-lite');
+var bufferEquals = require('buffer-equals');
 var sinonChai = require('./test-common');
 var linez = require('./linez');
 var expect = sinonChai.expect;
@@ -92,15 +94,15 @@ describe('linez', function () {
         it('converts doc into a buffer with toBuffer()', function () {
             var contents = Buffer.concat([
                 new Buffer([0xef, 0xbb, 0xbf]),
-                new Buffer('foo', 'utf8')
+                new Buffer('foo')
             ]);
             var doc = linez(contents);
-            expect(doc.toBuffer().equals(contents)).to.be.true;
+            expect(bufferEquals(doc.toBuffer(), contents)).to.be.true;
         });
         it('converts a signed doc into a buffer with toBuffer()', function () {
-            var contents = new Buffer('foo', 'utf8');
+            var contents = new Buffer('foo');
             var doc = linez(contents);
-            expect(doc.toBuffer().equals(contents)).to.be.true;
+            expect(bufferEquals(doc.toBuffer(), contents)).to.be.true;
         });
         it('converts an unsigned doc into a string with toString()', function () {
             var contents = 'foo\nbar';
@@ -118,7 +120,7 @@ describe('linez', function () {
             it('detects and decodes a utf-8-bom document', function () {
                 var doc = linez(Buffer.concat([
                     new Buffer([0xef, 0xbb, 0xbf]),
-                    new Buffer('foo', 'utf8')
+                    new Buffer('foo')
                 ]));
                 expect(doc.charset).to.eq('utf-8-bom');
                 expect(doc.lines[0].text).to.eq('foo');
@@ -126,7 +128,7 @@ describe('linez', function () {
             it('detects and decodes utf-16le bom document', function () {
                 var doc = linez(Buffer.concat([
                     new Buffer([0xff, 0xfe]),
-                    new Buffer('foo', 'utf16le')
+                    iconv.encode('foo', 'utf16le')
                 ]));
                 expect(doc.charset).to.eq('utf-16le');
                 expect(doc.lines[0].text).to.eq('foo');
@@ -134,7 +136,7 @@ describe('linez', function () {
             it('detects and decodes utf-16be bom document', function () {
                 var doc = linez(Buffer.concat([
                     new Buffer([0xfe, 0xff]),
-                    new Buffer('foo', 'utf16be')
+                    iconv.encode('foo', 'utf16be')
                 ]));
                 expect(doc.charset).to.eq('utf-16be');
                 expect(doc.lines[0].text).to.eq('foo');
@@ -152,7 +154,7 @@ describe('linez', function () {
                 expect(fn).to.throw('Unsupported charset: utf-32be');
             });
             it('decodes unsigned docs as utf8 by default', function () {
-                var doc = linez(new Buffer('foo', 'utf8'));
+                var doc = linez(new Buffer('foo'));
                 expect(doc.charset).to.be.empty;
                 expect(doc.lines[0].text).to.eq('foo');
             });

--- a/js/test-common.js
+++ b/js/test-common.js
@@ -1,4 +1,5 @@
 ///<reference path='../typings/tsd.d.ts'/>
+"use strict";
 var chai = require('chai');
 var sinonChai = require('sinon-chai');
 chai.use(sinonChai);

--- a/lib/linez.spec.ts
+++ b/lib/linez.spec.ts
@@ -5,7 +5,6 @@ import sinonChai = require('./test-common');
 import linez = require('./linez');
 
 var expect = sinonChai.expect;
-iconv.extendNodeEncodings();
 
 // ReSharper disable WrongExpressionStatement
 describe('linez', () => {
@@ -110,14 +109,14 @@ describe('linez', () => {
 		it('converts doc into a buffer with toBuffer()', () => {
 			var contents = Buffer.concat([
 				new Buffer([0xef, 0xbb, 0xbf]),
-				new Buffer('foo', 'utf8')
+				new Buffer('foo')
 			]);
 			var doc = linez(contents);
 			expect(bufferEquals(doc.toBuffer(), contents)).to.be.true;
 		});
 
 		it('converts a signed doc into a buffer with toBuffer()', () => {
-			var contents = new Buffer('foo', 'utf8');
+			var contents = new Buffer('foo');
 			var doc = linez(contents);
 			expect(bufferEquals(doc.toBuffer(), contents)).to.be.true;
 		});
@@ -141,7 +140,7 @@ describe('linez', () => {
 			it('detects and decodes a utf-8-bom document', () => {
 				var doc = linez(Buffer.concat([
 					new Buffer([0xef, 0xbb, 0xbf]),
-					new Buffer('foo', 'utf8')
+					new Buffer('foo')
 				]));
 				expect(doc.charset).to.eq('utf-8-bom');
 				expect(doc.lines[0].text).to.eq('foo');
@@ -150,7 +149,7 @@ describe('linez', () => {
 			it('detects and decodes utf-16le bom document', () => {
 				var doc = linez(Buffer.concat([
 					new Buffer([0xff, 0xfe]),
-					new Buffer('foo', 'utf16le')
+					iconv.encode('foo', 'utf16le')
 				]));
 				expect(doc.charset).to.eq('utf-16le');
 				expect(doc.lines[0].text).to.eq('foo');
@@ -159,7 +158,7 @@ describe('linez', () => {
 			it('detects and decodes utf-16be bom document', () => {
 				var doc = linez(Buffer.concat([
 					new Buffer([0xfe, 0xff]),
-					new Buffer('foo', 'utf16be')
+					iconv.encode('foo', 'utf16be')
 				]));
 				expect(doc.charset).to.eq('utf-16be');
 				expect(doc.lines[0].text).to.eq('foo');
@@ -180,12 +179,11 @@ describe('linez', () => {
 			});
 
 			it('decodes unsigned docs as utf8 by default', () => {
-				var doc = linez(new Buffer('foo', 'utf8'));
+				var doc = linez(new Buffer('foo'));
 				expect(doc.charset).to.be.empty;
 				expect(doc.lines[0].text).to.eq('foo');
 			});
 
 		});
 	});
-
 });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "through2": "^0.6.3"
   },
   "dependencies": {
-    "buffer-equals": "^1.0.3",
+    "buffer-equals": "^1.0.4",
     "iconv-lite": "^0.4.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "buffer-equals": "^1.0.3",
-    "iconv-lite": "0.4.11"
+    "iconv-lite": "^0.4.15"
   }
 }


### PR DESCRIPTION
Fixes #15 
- Node v4+ compatibility
- update `iconv-lite` to v0.4.15
- update code: https://github.com/ashtuchkin/iconv-lite/wiki/Node-v4-compatibility