### PR TITLE
support for code block

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+charset = utf-8
 indent_style = tab
 trim_trailing_whitespace = true
 end_of_line = lf

--- a/README.md
+++ b/README.md
@@ -97,17 +97,29 @@ By default, the document will attempt to be decoded as utf8. This is the default
 
 ### configure(options: IOptions)
 
-Configures linez to use the supplied options. Currently, only the newlines property is available, where you can specify any number of newline character sequences.
+Set the globle configures linez to use the supplied options. you can specify any number of newline character sequences in newlines property, and you can specify any number of code block options in block property.
 
 ```js
 linez.configure({
-  newlines: ['\n', '\r\n', '\r', '\u000B']
+  newlines: ['\n', '\r\n', '\r', '\u000B'],
+  blocks: [
+    {
+      type: 'multilineString',
+      start: /[^\\]".*\\\s*$/,
+      end: /[^\\]";?\s*$/,
+    },
+    {
+      type: 'multilineString',
+      start: /[^\\]'.*\\\s*$/,
+      end: /[^\\]';?\s*$/,
+    }
+  ]
 });
 ```
 
 ### resetConfiguration()
 
-Resets the configuration to the default settings, using `/\r?\n/g` as the newlines regular expression.
+Resets the globle configuration to the default settings, using `/\r?\n/g` as the newlines regular expression， useing multiline comments options as code block settings.
 
 
 ### Document
@@ -127,6 +139,7 @@ interface Line {
   number: number;
   text: string;
   ending: string;
+  blocks: { [type: string]: Line[] }[];
 }
 ```
 
@@ -134,12 +147,22 @@ interface Line {
 
 ```ts
 interface Options {
-  newlines?: string[];
+  newlines?: string[]|RegExp;
+  blocks?: BlockOptions[]|BlockOptions;
 }
 ```
 
+### BlockOptions
 
-### linez(file: string|Buffer): Document
+```ts
+interface BlockOptions {
+  type: string;
+  start: RegExp;
+  end: RegExp;
+}
+```
+
+### linez(file: string|Buffer, options?: IOptions): Document
 
 Parses text into a `Document`.
 

--- a/README.md
+++ b/README.md
@@ -97,29 +97,22 @@ By default, the document will attempt to be decoded as utf8. This is the default
 
 ### configure(options: IOptions)
 
-Set the globle configures linez to use the supplied options. you can specify any number of newline character sequences in newlines property, and you can specify any number of code block options in block property.
+Set the global configures linez to use the supplied options. you can specify any number of newline character sequences in newlines property, and you can specify any number of code block options in block property.
 
 ```js
 linez.configure({
   newlines: ['\n', '\r\n', '\r', '\u000B'],
-  blocks: [
-    {
-      type: 'multilineString',
-      start: /[^\\]".*\\\s*$/,
-      end: /[^\\]";?\s*$/,
-    },
-    {
-      type: 'multilineString',
-      start: /[^\\]'.*\\\s*$/,
-      end: /[^\\]';?\s*$/,
-    }
-  ]
+	blocks: [{
+		type: "multilineComment",
+		start: /^\s*\/\*+\s*$/,
+		end: /^\s*\*+\/\s*$/,
+	}]
 });
 ```
 
 ### resetConfiguration()
 
-Resets the globle configuration to the default settings, using `/\r?\n/g` as the newlines regular expression， useing multiline comments options as code block settings.
+Resets the global configuration to the default settings, using `/\r?\n/g` as the newlines regular expression， useing multiline comments options as code block settings.
 
 
 ### Document

--- a/lib/linez.spec.ts
+++ b/lib/linez.spec.ts
@@ -220,9 +220,9 @@ describe('linez', () => {
 				].join('\n'), {
 					blocks: [
 						{
-							type: "multilineComment",
+							type: 'multilineComment',
 							start: /^\s*\/\*+\s*$/,
-							end: /^\s*\*+\/\s*$/,
+							end: '*/',
 						},
 						{
 							type: 'multilineString',

--- a/lib/linez.ts
+++ b/lib/linez.ts
@@ -1,9 +1,9 @@
 ﻿import * as iconv from 'iconv-lite';
 import * as bufferEquals from 'buffer-equals';
+import objectAssign = require('object-assign');
 import WeakMap = require('es6-weak-map');
 import some = require('lodash.some');
 import StringFinder from './StringFinder';
-var objectAssign = require('object-assign');
 
 var boms: { [key: string]: Buffer } = {
 	'utf-8-bom': new Buffer([0xef, 0xbb, 0xbf]),

--- a/lib/linez.ts
+++ b/lib/linez.ts
@@ -86,13 +86,21 @@ function parseLines(text: string, options: linez.Options) {
 	return lines;
 }
 
+function testString(str: string, expression: string|RegExp) {
+	if (expression instanceof RegExp) {
+		return expression.test(str);
+	} else {
+		return str.trim() === expression;
+	}
+}
+
 function addBlockProp(lines: linez.Line[], blockOptions: linez.BlockOptions) {
 	var blockLines: linez.Line[]|null;
 
 	lines.forEach((line: linez.Line) => {
-		if (blockOptions.start.test(line.text)) {
+		if (testString(line.text, blockOptions.start)) {
 			blockLines = [line];
-		} else if (blockOptions.end.test(line.text)) {
+		} else if (testString(line.text, blockOptions.end)) {
 			if (blockLines) {
 				blockLines.push(line);
 				blockLines[0].block[blockOptions.type] = blockLines;
@@ -171,8 +179,8 @@ namespace linez {
 
 	export interface BlockOptions {
 		type: string;
-		start: RegExp;
-		end: RegExp;
+		start: string|RegExp;
+		end: string|RegExp;
 	}
 
 	export function configure(options?: Options) {
@@ -182,7 +190,7 @@ namespace linez {
 	export function resetConfiguration() {
 		globalOptions = {
 			blocks: {
-				type: "multilineComment",
+				type: 'multilineComment',
 				start: /^\s*\/\*+\s*$/,
 				end: /^\s*\*+\/\s*$/,
 			},

--- a/lib/linez.ts
+++ b/lib/linez.ts
@@ -1,6 +1,7 @@
 ﻿import * as iconv from 'iconv-lite';
 import * as bufferEquals from 'buffer-equals';
 import WeakMap = require('es6-weak-map');
+import some = require('lodash.some');
 import StringFinder from './StringFinder';
 var objectAssign = require('object-assign');
 
@@ -36,13 +37,14 @@ function linez(file: string|Buffer, options?: linez.Options): linez.Document {
 }
 
 function detectCharset(buffer: Buffer) {
-	for (var charset in boms) {
-		var bom = boms[charset];
+	var detectCharset;
+	some(boms, (bom, charset) => {
 		if (bufferEquals(buffer.slice(0, bom.length), bom)) {
+			detectCharset = charset;
 			return charset;
 		}
-	}
-	return '';
+	});
+	return detectCharset || '';
 }
 
 function parseLines(text: string, options: linez.Options) {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "buffer-equals": "^1.0.4",
     "es6-weak-map": "^2.0.2",
     "iconv-lite": "^0.4.15",
+    "lodash.some": "^4.6.0",
     "object-assign": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "buffer-equals": "^1.0.4",
+    "es6-weak-map": "^2.0.2",
     "iconv-lite": "^0.4.15",
     "object-assign": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lines": 100,
     "statements": 100,
     "functions": 100,
-    "branches": 94.12,
+    "branches": 96,
     "include": [
       "dist/**/*.js"
     ],
@@ -56,22 +56,23 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^3.4.35",
-    "@types/mocha": "^2.2.39",
-    "@types/node": "^7.0.5",
-    "@types/sinon": "^1.16.35",
+    "@types/mocha": "^2.2.40",
+    "@types/node": "^7.0.12",
+    "@types/sinon": "^2.1.2",
     "@types/sinon-chai": "^2.7.27",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
-    "nyc": "^10.1.2",
+    "nyc": "^10.2.0",
     "rimraf": "^2.6.1",
-    "sinon": "^1.17.7",
-    "sinon-chai": "^2.8.0",
-    "ts-node": "^2.1.0",
-    "tslint": "^4.5.1",
-    "typescript": "^2.2.1"
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0",
+    "ts-node": "^3.0.2",
+    "tslint": "^5.0.0",
+    "typescript": "^2.2.2"
   },
   "dependencies": {
     "buffer-equals": "^1.0.4",
-    "iconv-lite": "^0.4.15"
+    "iconv-lite": "^0.4.15",
+    "object-assign": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lines": 100,
     "statements": 100,
     "functions": 100,
-    "branches": 96,
+    "branches": 97,
     "include": [
       "dist/**/*.js"
     ],

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     "class-name": true,
     "curly": true,
     "eofline": true,
-    "forin": true,
     "label-position": true,
     "max-line-length": [true, 120],
     "no-arg": true,
@@ -30,7 +29,8 @@
     ],
     "quotemark": [false],
     "radix": true,
-    "semicolon": [true,
+    "semicolon": [
+      true,
       "always"
     ],
     "triple-equals": [true, "allow-null-check"],

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "class-name": true,
     "curly": true,
     "eofline": true,
+    "forin": true,
     "label-position": true,
     "max-line-length": [true, 120],
     "no-arg": true,
@@ -27,7 +28,11 @@
         "check-else",
         "check-whitespace"
     ],
-    "quotemark": [false],
+    "quotemark": [
+      true,
+      "single",
+      "avoid-escape"
+    ],
     "radix": true,
     "semicolon": [
       true,


### PR DESCRIPTION
- Added: local options for `linez(file: string|Buffer, options?: linez.Options)`
- Added:  `blocks` for interface `Options`
- Changed: update global configures and retuen currently configures by `linez.configure()`, Compatible with previous test cases
- Added: code block support, juse like multiline comments and multiline string

```javascript
/*
 * multiline comments
 */
var foo = "multiline \
string";
```
